### PR TITLE
app-card: Use app name for icon alt text

### DIFF
--- a/frontend/src/app/shared/components/app-card/app-card.component.html
+++ b/frontend/src/app/shared/components/app-card/app-card.component.html
@@ -10,7 +10,7 @@
         app.id + '.png'
       "
       class="rounded app-icon"
-      alt="Nimbus"
+      alt="{{ app.name | translateValue }}"
     />
   </div>
 


### PR DESCRIPTION
…instead of what appears to be a placeholder :)